### PR TITLE
Add configurable signaling and ICE server

### DIFF
--- a/src/components/PureWebRTCComponent.tsx
+++ b/src/components/PureWebRTCComponent.tsx
@@ -11,11 +11,11 @@ const PureWebRTCComponent: React.FC = () => {
   const peerConnection = useRef<RTCPeerConnection | null>(null);
   const [remoteId, setRemoteId] = React.useState<string>('');
 
-  const servers = {
-    iceServers: [
-      { urls: 'stun:stun.l.google.com:19302' }, // Google STUNサーバを使用
-    ],
-  };
+  const [signalingAddress, setSignalingAddress] = React.useState<string>('');
+  const [signalingPort, setSignalingPort] = React.useState<string>('');
+  const [iceServerAddress, setIceServerAddress] = React.useState<string>('stun.l.google.com');
+  const [iceServerPort, setIceServerPort] = React.useState<string>('19302');
+  const [iceServerType, setIceServerType] = React.useState<'stun' | 'turn'>('stun');
 
   useEffect(() => {
     if (localStream && localVideoRef.current) {
@@ -25,7 +25,12 @@ const PureWebRTCComponent: React.FC = () => {
   }, [localStream]);
 
   const createPeerConnection = () => {
-    peerConnection.current = new RTCPeerConnection(servers);
+    const configuration = {
+      iceServers: [
+        { urls: `${iceServerType}:${iceServerAddress}:${iceServerPort}` }
+      ],
+    } as RTCConfiguration;
+    peerConnection.current = new RTCPeerConnection(configuration);
 
     peerConnection.current.ontrack = (event) => {
       if (remoteVideoRef.current) {
@@ -51,9 +56,13 @@ const PureWebRTCComponent: React.FC = () => {
     createPeerConnection();
 
     const offer = await peerConnection.current?.createOffer();
+    if (!offer) return;
     await peerConnection.current?.setLocalDescription(offer);
 
-    console.log('Offer created:', JSON.stringify(offer));
+    console.log(
+      `Offer created with signaling ${signalingAddress}:${signalingPort} and ${iceServerType} server ${iceServerAddress}:${iceServerPort}`,
+      JSON.stringify(offer)
+    );
   };
 
   const handleAnswer = async (answer: RTCSessionDescriptionInit) => {
@@ -78,6 +87,53 @@ const PureWebRTCComponent: React.FC = () => {
         <video ref={remoteVideoRef} autoPlay playsInline width="320" height="240"></video>
       </div>
       <div>
+        <div>
+          <label>
+            Signaling Address:
+            <input
+              type="text"
+              value={signalingAddress}
+              onChange={(e) => setSignalingAddress(e.target.value)}
+              placeholder="127.0.0.1"
+            />
+          </label>
+          <label>
+            Signaling Port:
+            <input
+              type="text"
+              value={signalingPort}
+              onChange={(e) => setSignalingPort(e.target.value)}
+              placeholder="5000"
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            ICE Server Type:
+            <select value={iceServerType} onChange={(e) => setIceServerType(e.target.value as 'stun' | 'turn')}>
+              <option value="stun">STUN</option>
+              <option value="turn">TURN</option>
+            </select>
+          </label>
+          <label>
+            Server Address:
+            <input
+              type="text"
+              value={iceServerAddress}
+              onChange={(e) => setIceServerAddress(e.target.value)}
+              placeholder="stun.example.com"
+            />
+          </label>
+          <label>
+            Port:
+            <input
+              type="text"
+              value={iceServerPort}
+              onChange={(e) => setIceServerPort(e.target.value)}
+              placeholder="3478"
+            />
+          </label>
+        </div>
         <button onClick={createOffer}>Create Offer</button>
         {/* オファーを受け取るには handleOffer を外部の signaling server から呼び出す */}
         <input


### PR DESCRIPTION
## Summary
- allow specifying signaling and ICE server parameters
- build RTC configuration from the new form

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_683fc17aa9388332baf6d8d370b8e55c